### PR TITLE
Fix cruise fault on startup with slow or no internet (#156)

### DIFF
--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -8,7 +8,6 @@ from selfdrive.car.fw_versions import get_fw_versions, match_fw_to_car
 from selfdrive.swaglog import cloudlog
 import cereal.messaging as messaging
 from selfdrive.car import gen_empty_fingerprint
-from selfdrive.crash import client
 
 from cereal import car, log
 EventName = car.CarEvent.EventName
@@ -160,7 +159,6 @@ def fingerprint(logcan, sendcan, has_relay):
     source = car.CarParams.FingerprintSource.fixed
 
   cloudlog.warning("fingerprinted %s", car_fingerprint)
-  client.captureMessage("fingerprinted {}".format(car_fingerprint), level='info')
   return car_fingerprint, finger, vin, car_fw, source
 
 


### PR DESCRIPTION
* Fix cruise faults due to sentry taking long time to timeout when no internet

* 30 second maximum timeout, don't keep retrying